### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/reinvent-2019/rhythm-cloud/lambda/Greengrass_startSong/botocore/data/lambda/2015-03-31/service-2.json
+++ b/reinvent-2019/rhythm-cloud/lambda/Greengrass_startSong/botocore/data/lambda/2015-03-31/service-2.json
@@ -2728,7 +2728,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs10.x",
+        "nodejs14.x",
         "java8",
         "python2.7",
         "python3.6",

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/apis/lambda-2015-03-31.examples.json
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/apis/lambda-2015-03-31.examples.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs10.x",
+              "Runtime": "nodejs14.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs10.x",
+              "Runtime": "nodejs14.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/clients/lambda.d.ts
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/clients/lambda.d.ts
@@ -1939,7 +1939,7 @@ declare namespace Lambda {
   export type ReservedConcurrentExecutions = number;
   export type ResourceArn = string;
   export type RoleArn = string;
-  export type Runtime = "nodejs"|"nodejs4.3"|"nodejs6.10"|"nodejs8.10"|"nodejs10.x"|"nodejs12.x"|"java8"|"java11"|"python2.7"|"python3.6"|"python3.7"|"python3.8"|"dotnetcore1.0"|"dotnetcore2.0"|"dotnetcore2.1"|"dotnetcore3.1"|"nodejs4.3-edge"|"go1.x"|"ruby2.5"|"ruby2.7"|"provided"|string;
+  export type Runtime = "nodejs"|"nodejs4.3"|"nodejs6.10"|"nodejs8.10"|"nodejs14.x"|"nodejs12.x"|"java8"|"java11"|"python2.7"|"python3.6"|"python3.7"|"python3.8"|"dotnetcore1.0"|"dotnetcore2.0"|"dotnetcore2.1"|"dotnetcore3.1"|"nodejs4.3-edge"|"go1.x"|"ruby2.5"|"ruby2.7"|"provided"|string;
   export type S3Bucket = string;
   export type S3Key = string;
   export type S3ObjectVersion = string;

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/clients/securityhub.d.ts
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/get-score/package/clients/securityhub.d.ts
@@ -1121,7 +1121,7 @@ declare namespace SecurityHub {
      */
     Version?: AwsLambdaLayerVersionNumber;
     /**
-     * The layer's compatible runtimes. Maximum number of five items. Valid values: nodejs10.x | nodejs12.x | java8 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore1.0 | dotnetcore2.1 | go1.x | ruby2.5 | provided 
+     * The layer's compatible runtimes. Maximum number of five items. Valid values: nodejs14.x | nodejs12.x | java8 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore1.0 | dotnetcore2.1 | go1.x | ruby2.5 | provided 
      */
     CompatibleRuntimes?: NonEmptyStringList;
     /**

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/apis/lambda-2015-03-31.examples.json
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/apis/lambda-2015-03-31.examples.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs10.x",
+              "Runtime": "nodejs14.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs10.x",
+              "Runtime": "nodejs14.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/clients/lambda.d.ts
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/clients/lambda.d.ts
@@ -1939,7 +1939,7 @@ declare namespace Lambda {
   export type ReservedConcurrentExecutions = number;
   export type ResourceArn = string;
   export type RoleArn = string;
-  export type Runtime = "nodejs"|"nodejs4.3"|"nodejs6.10"|"nodejs8.10"|"nodejs10.x"|"nodejs12.x"|"java8"|"java11"|"python2.7"|"python3.6"|"python3.7"|"python3.8"|"dotnetcore1.0"|"dotnetcore2.0"|"dotnetcore2.1"|"dotnetcore3.1"|"nodejs4.3-edge"|"go1.x"|"ruby2.5"|"ruby2.7"|"provided"|string;
+  export type Runtime = "nodejs"|"nodejs4.3"|"nodejs6.10"|"nodejs8.10"|"nodejs14.x"|"nodejs12.x"|"java8"|"java11"|"python2.7"|"python3.6"|"python3.7"|"python3.8"|"dotnetcore1.0"|"dotnetcore2.0"|"dotnetcore2.1"|"dotnetcore3.1"|"nodejs4.3-edge"|"go1.x"|"ruby2.5"|"ruby2.7"|"provided"|string;
   export type S3Bucket = string;
   export type S3Key = string;
   export type S3ObjectVersion = string;

--- a/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/clients/securityhub.d.ts
+++ b/reinvent-2020/RhythmCloud/analytics/rhythm-score/package/clients/securityhub.d.ts
@@ -1121,7 +1121,7 @@ declare namespace SecurityHub {
      */
     Version?: AwsLambdaLayerVersionNumber;
     /**
-     * The layer's compatible runtimes. Maximum number of five items. Valid values: nodejs10.x | nodejs12.x | java8 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore1.0 | dotnetcore2.1 | go1.x | ruby2.5 | provided 
+     * The layer's compatible runtimes. Maximum number of five items. Valid values: nodejs14.x | nodejs12.x | java8 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore1.0 | dotnetcore2.1 | go1.x | ruby2.5 | provided 
      */
     CompatibleRuntimes?: NonEmptyStringList;
     /**

--- a/reinvent-2020/RhythmCloud/lambda/Greengrass_startSong/botocore/data/lambda/2015-03-31/service-2.json
+++ b/reinvent-2020/RhythmCloud/lambda/Greengrass_startSong/botocore/data/lambda/2015-03-31/service-2.json
@@ -2728,7 +2728,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs10.x",
+        "nodejs14.x",
         "java8",
         "python2.7",
         "python3.6",


### PR DESCRIPTION
CloudFormation templates in aws-builders-fair-projects have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.